### PR TITLE
Change prepared coffee icon to teapot

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -776,7 +776,7 @@
                                 <span class="text-sm ${(p.totalContribue || 0) >= 0 ? 'text-success' : 'text-danger'} font-medium">
                                     ${(p.totalContribue || 0).toFixed(2)}€
                                 </span>
-                                ${(p.preparationsCompte || 0) > 0 ? `<span class="preparation-count">${p.preparationsCompte || 0} ☕</span>` : ''}
+                                ${(p.preparationsCompte || 0) > 0 ? `<span class="preparation-count">${p.preparationsCompte || 0} 🫖</span>` : ''}
                             </div>
                         </div>
                         <div class="text-xl">


### PR DESCRIPTION
## Summary
- use a teapot emoji for the count of prepared coffees so it differs from the cup used for coffees consumed

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d919e97cc832a9d4a2839e2eafb04