### PR TITLE
Add selectable avatar images

### DIFF
--- a/public/avatars/avatar1.svg
+++ b/public/avatars/avatar1.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <circle cx="24" cy="24" r="22" fill="#4ade80"/>
+</svg>

--- a/public/avatars/avatar2.svg
+++ b/public/avatars/avatar2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <rect x="4" y="4" width="40" height="40" rx="8" fill="#60a5fa"/>
+</svg>

--- a/public/avatars/avatar3.svg
+++ b/public/avatars/avatar3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <polygon points="24,4 44,44 4,44" fill="#facc15"/>
+</svg>

--- a/public/avatars/avatar4.svg
+++ b/public/avatars/avatar4.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <path d="M24 4l18 10v20l-18 10L6 34V14z" fill="#f472b6"/>
+</svg>

--- a/public/avatars/avatar5.svg
+++ b/public/avatars/avatar5.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <circle cx="24" cy="16" r="8" fill="#93c5fd"/>
+  <path d="M12 44c0-8 8-12 12-12s12 4 12 12" fill="#93c5fd"/>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -803,13 +803,20 @@
                             </div>
                         </div>
                         <div class="flex flex-col items-end">
-                            <div class="text-xl">${escapeHtml(p.avatar || '🙂')}</div>
+                            ${p.avatar && p.avatar.endsWith('.svg')
+                                ? `<img src="${escapeHtml(p.avatar)}" alt="avatar" class="w-6 h-6">`
+                                : `<div class="text-xl">${escapeHtml(p.avatar || '🙂')}</div>`}
                             <select onchange="changerAvatarParticipant('${p.id}', this.value)" class="input px-1 py-0.5 text-xs mt-1">
                                 <option value="🙂" ${p.avatar === '🙂' ? 'selected' : ''}>🙂</option>
                                 <option value="😀" ${p.avatar === '😀' ? 'selected' : ''}>😀</option>
                                 <option value="😎" ${p.avatar === '😎' ? 'selected' : ''}>😎</option>
                                 <option value="😃" ${p.avatar === '😃' ? 'selected' : ''}>😃</option>
                                 <option value="☕" ${p.avatar === '☕' ? 'selected' : ''}>☕</option>
+                                <option value="avatars/avatar1.svg" ${p.avatar === 'avatars/avatar1.svg' ? 'selected' : ''}>Avatar 1</option>
+                                <option value="avatars/avatar2.svg" ${p.avatar === 'avatars/avatar2.svg' ? 'selected' : ''}>Avatar 2</option>
+                                <option value="avatars/avatar3.svg" ${p.avatar === 'avatars/avatar3.svg' ? 'selected' : ''}>Avatar 3</option>
+                                <option value="avatars/avatar4.svg" ${p.avatar === 'avatars/avatar4.svg' ? 'selected' : ''}>Avatar 4</option>
+                                <option value="avatars/avatar5.svg" ${p.avatar === 'avatars/avatar5.svg' ? 'selected' : ''}>Avatar 5</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- provide basic SVG icons in `public/avatars`
- extend avatar selection dropdown
- show an `<img>` when avatar points to an image

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d9a1b0e3c832ab7e860398a436515